### PR TITLE
Send bye message when stream closes

### DIFF
--- a/src/unrepl/repl.clj
+++ b/src/unrepl/repl.clj
@@ -288,5 +288,5 @@
                     (ensure-unrepl)
                     (let [{:keys [::ex ::phase]
                            :or {ex e phase :repl}} (ex-data e)]
-                      (write [:exception {:ex e :phase phase} @eval-id]))))))))
-
+                      (write [:exception {:ex e :phase phase} @eval-id]))))
+        (write [:bye])))))


### PR DESCRIPTION
This allows clients to detect when the EDN stream finishes.