### PR TITLE
Make side-loader's hello tag a keyword.

### DIFF
--- a/src/unrepl/repl.clj
+++ b/src/unrepl/repl.clj
@@ -242,7 +242,7 @@
               (prn x))))))))
 
 (defn attach-sideloader! [session-id]
-  (prn '[unrepl.jvm.side-loader/hello])
+  (prn '[:unrepl.jvm.side-loader/hello])
   (some-> session-id session :side-loader 
     (reset!
       (let [out *out*


### PR DESCRIPTION
This way it's easier to be regexp'd alongside with `:unrepl/hello` tag.