### PR TITLE
Make it possible to read custom session actions from EDN files

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,4 +8,13 @@ Either you get `[:unrepl.upgrade/failed]` or `[:unrepl/hello ...]` on the repl o
 
 Each use of the blob creates gensymed namespaces.
 
-You can customize the blob: enter `lein unrepl-make-blob target-file '{...here goes custom session actions..}'`. Actions who have a qualified symbol as first in topmost function position will automatically require this namespace on first use.  
+You can customize the blob: enter `lein unrepl-make-blob <target-file> <session actions map>`. Where the session actions map can be either a string or a `.edn` file. For example:
+
+```
+# As a string
+$> lein unrepl-make-blob foo-blob.clj '{:my.own/action (foo/bar #unrepl/param :baz)}'
+# As a file
+$> lein unrepl-make-blob foo-blob.clj custom-actions.edn
+```
+
+If a custom action has a qualified symbol as the first element (function symbol) for its topmost form, this qualified symbol's namespace will automatically be required on the first use of the action.

--- a/tasks/leiningen/unrepl_make_blob.clj
+++ b/tasks/leiningen/unrepl_make_blob.clj
@@ -24,7 +24,8 @@
 (defn unrepl-make-blob
   ([project] (unrepl-make-blob project "resources/unrepl/blob.clj" "{}"))
   ([project target session-actions]
-    (let [session-actions-map (edn/read-string {:default (fn [tag data] (tagged-literal 'unrepl-make-blob-unquote (list 'tagged-literal (tagged-literal 'unrepl-make-blob-quote tag) data)))} session-actions)
+    (let [session-actions-source (if (clojure.string/ends-with? session-actions ".edn") (slurp session-actions) session-actions)
+          session-actions-map (edn/read-string {:default (fn [tag data] (tagged-literal 'unrepl-make-blob-unquote (list 'tagged-literal (tagged-literal 'unrepl-make-blob-quote tag) data)))} session-actions-source)
           code (str (slurp "src/unrepl/print.clj") (slurp "src/unrepl/repl.clj") "\n(ns user)\n(unrepl.repl/start)")]
       (if (map? session-actions-map)
         (let [session-actions-map (into session-actions-map

--- a/tasks/leiningen/unrepl_make_blob.clj
+++ b/tasks/leiningen/unrepl_make_blob.clj
@@ -24,7 +24,7 @@
 (defn unrepl-make-blob
   ([project] (unrepl-make-blob project "resources/unrepl/blob.clj" "{}"))
   ([project target session-actions]
-    (let [session-actions-source (if (clojure.string/ends-with? session-actions ".edn") (slurp session-actions) session-actions)
+    (let [session-actions-source (if (re-find #"^\s*\{" session-actions) session-actions (slurp session-actions))
           session-actions-map (edn/read-string {:default (fn [tag data] (tagged-literal 'unrepl-make-blob-unquote (list 'tagged-literal (tagged-literal 'unrepl-make-blob-quote tag) data)))} session-actions-source)
           code (str (slurp "src/unrepl/print.clj") (slurp "src/unrepl/repl.clj") "\n(ns user)\n(unrepl.repl/start)")]
       (if (map? session-actions-map)


### PR DESCRIPTION
This commit will let client authors specify their custom actions in a vcs-able
way.  Changes in UPGRADE.md explain usage.

Example: https://github.com/Unrepl/unrepl.el/commit/c3135e0a7b95066e7f6a183fb728b616b653cb91