### PR TITLE
Fix `print-vs` looping stop condition.

### DIFF
--- a/src/unrepl/print.clj
+++ b/src/unrepl/print.clj
@@ -100,16 +100,14 @@
   [write vs rem-depth]
   (let [print-length *print-length*]
     (loop [vs vs i 0]
-      (if (and (< i print-length) (may-print? vs))
-        (when-some [[v :as vs] (blame-seq vs)]
-          (when (pos? i) (write " "))
+      (when-some [[v :as vs] (blame-seq vs)]
+        (when (pos? i) (write " "))
+        (if (and (< i print-length) (may-print? vs))
           (if (and (tagged-literal? v) (= (:tag v) 'unrepl/lazy-error))
             (print-on write v rem-depth)
-           (do
-             (print-on write v rem-depth)
-             (recur (rest vs) (inc i)))))
-        (do
-          (when (pos? i) (write " "))
+            (do
+              (print-on write v rem-depth)
+              (recur (rest vs) (inc i))))
           (print-on write (tagged-literal 'unrepl/... (*elide* vs)) rem-depth))))))
 
 (defrecord ElidedKVs [s]


### PR DESCRIPTION
When a seq had length multiple of *print-length*, the looping didn't stop correctly and it would include an unnecessary elision that would resolve to `nil`.

Example:

```
> (range 10)
(1 2 3 4 5 6 7 8 9 ...)
```

Elision resolves to `nil`, since there's no reminder to the sequence.