### PR TITLE
Backport Throwable->map from Clojure 1.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ pom.xml.asc
 .nrepl-port
 .hgignore
 .hg/
+resources

--- a/src/unrepl/print.clj
+++ b/src/unrepl/print.clj
@@ -254,12 +254,12 @@
 ;; use standard implementation if running in Clojure 1.9 or above,
 ;; backported version otherwise
 
-(defn Throwable->map'' [^Throwable o]
+(def Throwable->map''
   (if (or
        (-> *clojure-version* :major (> 1))
        (-> *clojure-version* :minor (>= 9)))
-    (Throwable->map o)
-    (Throwable->map' o)))
+    Throwable->map
+    Throwable->map'))
 
 ;; --
 


### PR DESCRIPTION
Throwable->map backport from Clojure 1.9

The behavior of clojure.core/Throwable->map changed from 1.8 to 1.9. We need the (more correct) behavior in 1.9.
