### PR TITLE
Read session action as EDN map

### DIFF
--- a/src/unrepl/blob-template.clj
+++ b/src/unrepl/blob-template.clj
@@ -9,4 +9,4 @@
 <BLOB-PAYLOAD>
 <<<FIN
 (clojure.core/ns user)
-(unrepl.repl/start (read))
+(unrepl.repl/start (unrepl.repl/read-ext-session-actions))

--- a/src/unrepl/make_blob.clj
+++ b/src/unrepl/make_blob.clj
@@ -56,7 +56,7 @@
         regular s))
     (str sb)))
 
-(defn- gen-blob [session-actions]
+(defn- gen-blob []
   (let [template (slurp (io/resource "unrepl/blob-template.clj"))
         shaded-code-sb (StringBuilder.)
         shaded-libs (shade/shade 'unrepl.repl
@@ -66,26 +66,10 @@
                (str/replace "unrepl.repl"
                  (str (shaded-libs 'unrepl.repl)))
                (str/replace "<BLOB-PAYLOAD>" (str shaded-code-sb)))]
-    (str (strip-spaces-and-comments code) "\n" session-actions "\n"))) ; newline to force eval by the repl
+    (str (strip-spaces-and-comments code) "\n"))) ; newline to force eval by the repl
 
 (defn -main
-  ([] (-main "resources/unrepl/blob.clj" "{}"))
-  ([target session-actions]
+  ([] (-main "resources/unrepl/blob.clj"))
+  ([target]
     (-> target io/file .getParentFile .mkdirs)
-    (let [session-actions-source (if (re-find #"^\s*\{" session-actions) session-actions (slurp session-actions))
-          session-actions-map (edn/read-string {:default (fn [tag data] (tagged-literal 'unrepl-make-blob-unquote (list 'tagged-literal (tagged-literal 'unrepl-make-blob-quote tag) data)))} session-actions-source)]
-      (if (map? session-actions-map)
-        (let [session-actions-map (into session-actions-map
-                                    (map (fn [[k v]]
-                                           [k (tagged-literal 'unrepl-make-blob-syntaxquote
-                                                (if (and (seq? v) (symbol? (first v)) (namespace (first v)))
-                                                  (list 'unrepl.repl/ensure-ns v)
-                                                  v))]))
-                                    session-actions-map)
-              session-actions (-> session-actions-map pr-str 
-                                (str/replace #"#unrepl-make-blob-(?:syntax|un)?quote " {"#unrepl-make-blob-syntaxquote " "`"
-                                                                                        "#unrepl-make-blob-unquote " "~"
-                                                                                        "#unrepl-make-blob-quote " "'"}))]
-          (spit target (gen-blob session-actions)))
-        (println "The arguments must be: a target file name and an EDN map.")))))
-
+    (spit target (gen-blob))))

--- a/src/unrepl/repl.clj
+++ b/src/unrepl/repl.clj
@@ -278,6 +278,18 @@
                              eval-id])))))
       request-prompt)))
 
+(defn read-ext-session-actions
+  []
+  (->> (edn/read {:default tagged-literal} *in*)
+    (into {} (map (fn [[k v]]
+                    [k (if (and (seq? v)
+                                (symbol? (first v))
+                                (namespace (first v)))
+                         `(do
+                            (require '~(symbol (namespace (first v))))
+                            ~v)
+                         v)])))))
+
 (defn start [ext-session-actions]
   (with-local-vars [prompt-vars #{#'*ns* #'*warn-on-reflection*}
                     current-eval-future nil]
@@ -416,8 +428,3 @@
       (start)
       (finally
         (.setContextClassLoader (Thread/currentThread) cl)))))
-
-(defmacro ensure-ns [[fully-qualified-var-name & args :as expr]]
-  `(do
-     (require '~(symbol (namespace fully-qualified-var-name)))
-     ~expr))


### PR DESCRIPTION
In particular this means that actions need not be present on blob
generation. For a static client this is not really relevant. However
a client which wants to provide extension points for dynamically
added actions has to run make-blob every time an extension is added
or removed. This is non-trivial business. With this change the blob
update is not necessary anymore.

Read: one compile step removed.