### PR TITLE
Fix nREPL website link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A REPL-centric approach to tooling, by means of a general purpose stream-based REPL protocol.
 
-Unrepl is the common base for a set of REPL protocols.  It is meant as an upgrade-path from a more basic [nREPL](https://nrepl.xyz) or [Socket REPL](https://clojure.org/reference/repl_and_main#_launching_a_socket_server), and allows different Unrepl-based clients to implement their own extensions to the REPL protocol (e.g. for IDE integration).  Such Unrepl-based clients would send their own server payload ("blob") through the basic REPL connection into the target process, to upgrade the server side of this connection with the desired features.  After this upgrade, the client could use the new features on the existing REPL connection.
+Unrepl is the common base for a set of REPL protocols.  It is meant as an upgrade-path from a more basic [nREPL](https://nrepl.org/) or [Socket REPL](https://clojure.org/reference/repl_and_main#_launching_a_socket_server), and allows different Unrepl-based clients to implement their own extensions to the REPL protocol (e.g. for IDE integration).  Such Unrepl-based clients would send their own server payload ("blob") through the basic REPL connection into the target process, to upgrade the server side of this connection with the desired features.  After this upgrade, the client could use the new features on the existing REPL connection.
 
 The benefit of this process is, that the target process does not need to include REPL code beyond Socket REPL, which is already included in Clojure 1.8+.  Everything else is loaded only when needed and can be extended according to the needs of the client.  Due to the shared common base, it should be easy to share parts of the server implementation between different Unrepl derivatives.
 


### PR DESCRIPTION
nREPL moved from nrepl.xyz to nrepl.org