### PR TITLE
Use `pr-str` for generic Java objects

### DIFF
--- a/src/unrepl/printer.clj
+++ b/src/unrepl/printer.clj
@@ -442,7 +442,7 @@
       (print-trusted-tag-lit-on write "unrepl/object"
                                 [(class x) (format "0x%x" (System/identityHashCode x)) (object-representation x)
                                  {:bean {unreachable (tagged-literal 'unrepl/... (*elide* (ElidedKVs. (bean x))))}
-                                  :pr-str (pr-str x)}}]
+                                  :pr-str (pr-str x)}]
                                 (sat-inc rem-depth))))) ; is very trusted
 
 (defn edn-str [x]

--- a/src/unrepl/printer.clj
+++ b/src/unrepl/printer.clj
@@ -441,7 +441,8 @@
       :else
       (print-trusted-tag-lit-on write "unrepl/object"
                                 [(class x) (format "0x%x" (System/identityHashCode x)) (object-representation x)
-                                 {:bean {unreachable (tagged-literal 'unrepl/... (*elide* (ElidedKVs. (bean x))))}}]
+                                 {:bean {unreachable (tagged-literal 'unrepl/... (*elide* (ElidedKVs. (bean x))))}
+                                  :pr-str (pr-str x)}}]
                                 (sat-inc rem-depth))))) ; is very trusted
 
 (defn edn-str [x]


### PR DESCRIPTION
When evaluating any other object that is not native from Clojure, sometimes the object implements `print-method`. With unrepl, these objects become difficult to read as it prints an internal Java interpretation of the object (this is specially true for datomic's datoms that, when using `prn`, print as Clojure's vectors/lists/maps but with Unrepl they print as `#unrepl/object`).

This proposal adds a `:pr-str` key (or any better name you can think of) so that clients can use it to pretty-print objects if they find fit.

WDYT?